### PR TITLE
#2 Bugfix dragging marker breaks its location

### DIFF
--- a/src/stores/markers.ts
+++ b/src/stores/markers.ts
@@ -25,11 +25,11 @@ export const useMarkersStore = defineStore('markers', {
       const truncatedLng = truncateFloat(lng, 5)
       this.markers[this.selectedMarker] = [truncatedLat, truncatedLng]
     },
-    updateMarkerOnDrag(e: { target: { getLatLng: () => LatLng } }) {
+    updateMarkerOnDrag(e: { target: { getLatLng: () => LatLng } }, index: number) {
       const { lat, lng } = e.target.getLatLng()
       const truncatedLat = truncateFloat(lat, 5)
       const truncatedLng = truncateFloat(lng, 5)
-      this.markers[this.selectedMarker] = [truncatedLat, truncatedLng]
+      this.markers[index] = [truncatedLat, truncatedLng]
     },
     removeMarker(index: number) {
       this.markers.splice(index, 1)

--- a/src/stores/markers.ts
+++ b/src/stores/markers.ts
@@ -25,7 +25,7 @@ export const useMarkersStore = defineStore('markers', {
       const truncatedLng = truncateFloat(lng, 5)
       this.markers[this.selectedMarker] = [truncatedLat, truncatedLng]
     },
-    addMarkerOnDrag(e: { target: { getLatLng: () => LatLng } }) {
+    updateMarkerOnDrag(e: { target: { getLatLng: () => LatLng } }) {
       const { lat, lng } = e.target.getLatLng()
       const truncatedLat = truncateFloat(lat, 5)
       const truncatedLng = truncateFloat(lng, 5)

--- a/src/views/map/Marker.vue
+++ b/src/views/map/Marker.vue
@@ -5,7 +5,7 @@
     :lat-lng="marker as LatLngExpression"
     :icon="index === markerStore.selectedMarker ? SELECT_MARKER : DEFAULT_ICON"
     draggable
-    @dragend="markerStore.updateMarkerOnDrag"
+    @dragend="markerStore.updateMarkerOnDrag($event, index)"
     @click="markerStore.setSelectedMarker(index)"
   ></l-marker>
 </template>

--- a/src/views/map/Marker.vue
+++ b/src/views/map/Marker.vue
@@ -5,7 +5,7 @@
     :lat-lng="marker as LatLngExpression"
     :icon="index === markerStore.selectedMarker ? SELECT_MARKER : DEFAULT_ICON"
     draggable
-    @dragend="markerStore.addMarkerOnDrag"
+    @dragend="markerStore.updateMarkerOnDrag"
     @click="markerStore.setSelectedMarker(index)"
   ></l-marker>
 </template>


### PR DESCRIPTION
This fixes marker dragging bug.
- Rename onDrag marker coordinate setter to represent its functionality
- Use provided marker index, instead of selectedMarker